### PR TITLE
Add requirement that rate provided is less than 100

### DIFF
--- a/contracts/CryptoCareMinter.sol
+++ b/contracts/CryptoCareMinter.sol
@@ -43,6 +43,7 @@ contract CryptoCareMinter is Ownable, Pausable {
         require(!usedNonces[_nonce]);
         require(beneficiaries[_beneficiaryId].addr > 0);
         require(beneficiaries[_beneficiaryId].isActive);
+        require(_rate < 100);
         require(verifyMessage(keccak256(abi.encodePacked(_to, _tokenURI, _beneficiaryId, _nonce, msg.value)), v, r, s));
         usedNonces[_nonce] = true;
 

--- a/test/cryptocare.js
+++ b/test/cryptocare.js
@@ -156,6 +156,17 @@ contract('CryptoCareMinter', (accounts) => {
         ).should.be.rejectedWith('revert');
       });
 
+      it('rejects when rate is greater than 100', async function() {
+        const nonce = 100;
+        const { v, r, s } = await generateSignature(
+          this.web3, this.toAddress, this.tokenUri, this.beneficiaryId, nonce, this.msgValue, this.minterPrivKey
+        );
+
+        await this.contract.mintTo.call(
+          this.toAddress, this.beneficiaryId, this.tokenUri, nonce, 101, v, r, s, this.transactionMsg
+        ).should.be.rejectedWith('revert');
+      });
+
       it('rejects when the contract is paused', async function() {
         const nonce = 1;
         const { v, r, s } = await generateSignature(


### PR DESCRIPTION
The override rate being set will catch this edge-case, but if it is not set, then the caller can pass a rate of > 100 which would cause a negative amount to be attempted to send to the beneficiary.